### PR TITLE
feature: order controller methods by code line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,14 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // asm
+    implementation 'org.ow2.asm:asm:9.2'
+    implementation 'org.ow2.asm:asm-tree:9.2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -30,6 +36,9 @@ publishing {
         mavenJava(MavenPublication) {
             from components.java
         }
+    }
+    repositories {
+        mavenLocal()
     }
 }
 

--- a/src/main/java/com/test/swaggercustom/TestController.java
+++ b/src/main/java/com/test/swaggercustom/TestController.java
@@ -1,0 +1,29 @@
+package com.test.swaggercustom;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Plan API for Test")
+@RestController
+@RequestMapping(value = "/plan")
+public class TestController {
+
+    @Operation(summary = "추천 일정 가져오기")
+    @GetMapping("/recommended")
+    public void getRecommendedPlan() {
+    }
+
+    @Operation(summary = "일정 추가하기")
+    @PostMapping
+    public void createPlan() {
+    }
+
+    @Operation(summary = "일정 가져오기")
+    @GetMapping
+    public void getPlan() {
+    }
+}

--- a/src/main/java/com/test/swaggercustom/config/SwaggerConfig.java
+++ b/src/main/java/com/test/swaggercustom/config/SwaggerConfig.java
@@ -1,19 +1,54 @@
 package com.test.swaggercustom.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import org.springdoc.core.models.GroupedOpenApi;
+import com.test.swaggercustom.utils.ControllerMethodOrderUtil;
+import io.swagger.v3.oas.models.Paths;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Controller;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 
 @Configuration
 public class SwaggerConfig {
 
+    private final ApplicationContext applicationContext;
+
+    public SwaggerConfig(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
     @Bean
-    public GroupedOpenApi customOpenApi() {
-        return GroupedOpenApi.builder()
-                .group("custom-api")
-                .pathsToMatch("/api/**")
-                .build();
+    public OpenApiCustomizer sortOperationsCustomizer() {
+        return openApi -> {
+            Map<String, Object> controllers = applicationContext.getBeansWithAnnotation(Controller.class);
+            List<String> sortedPathsOrder = new ArrayList<>();
+            controllers.values().forEach(controller -> {
+                Class<?> controllerClass = controller.getClass();
+                List<Method> orderedMethods = ControllerMethodOrderUtil.getOrderedMethods(controllerClass);
+                orderedMethods.forEach(method -> {
+                    String[] paths = ControllerMethodOrderUtil.getMethodPaths(controllerClass, method);
+                    for (String path : paths) {
+                        if (!sortedPathsOrder.contains(path)) {
+                            sortedPathsOrder.add(path);
+                        }
+                    }
+                });
+            });
+
+            Paths sortedPaths = new Paths();
+            sortedPathsOrder.forEach(path -> {
+                if (openApi.getPaths().get(path) != null) {
+                    sortedPaths.addPathItem(path, openApi.getPaths().get(path));
+                }
+            });
+            openApi.setPaths(sortedPaths);
+        };
     }
 }
+

--- a/src/main/java/com/test/swaggercustom/utils/ControllerMethodOrderUtil.java
+++ b/src/main/java/com/test/swaggercustom/utils/ControllerMethodOrderUtil.java
@@ -1,0 +1,68 @@
+package com.test.swaggercustom.utils;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.springframework.web.bind.annotation.*;
+
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ControllerMethodOrderUtil {
+    public static List<Method> getOrderedMethods(Class<?> controllerClass) {
+        try {
+            // ASM을 사용하여 클래스의 메서드 순서를 읽어옴
+            ClassReader classReader = new ClassReader(controllerClass.getName());
+            ClassNode classNode = new ClassNode();
+            classReader.accept(classNode, 0);
+
+            // 원래 순서대로 메서드 이름 리스트를 생성
+            List<String> methodNamesInOrder = classNode.methods.stream()
+                    .map(methodNode -> methodNode.name)
+                    .toList();
+
+            // Reflection을 사용하여 메서드 리스트를 가져옴
+            Method[] methods = controllerClass.getDeclaredMethods();
+
+            // 메서드를 원래 순서에 따라 정렬
+            return Arrays.stream(methods)
+                    .sorted((m1, m2) -> {
+                        int index1 = methodNamesInOrder.indexOf(m1.getName());
+                        int index2 = methodNamesInOrder.indexOf(m2.getName());
+                        return Integer.compare(index1, index2);
+                    })
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read class with ASM", e);
+        }
+    }
+
+    public static String[] getMethodPaths(Class<?> controllerClass, Method method) {
+        RequestMapping classRequestMapping = controllerClass.getAnnotation(RequestMapping.class);
+        String[] classPaths = (classRequestMapping != null) ? classRequestMapping.value() : new String[]{""};
+
+        String[] methodPaths = new String[0];
+        if (method.isAnnotationPresent(GetMapping.class)) {
+            methodPaths = method.getAnnotation(GetMapping.class).value();
+        } else if (method.isAnnotationPresent(PostMapping.class)) {
+            methodPaths = method.getAnnotation(PostMapping.class).value();
+        } else if (method.isAnnotationPresent(PutMapping.class)) {
+            methodPaths = method.getAnnotation(PutMapping.class).value();
+        } else if (method.isAnnotationPresent(DeleteMapping.class)) {
+            methodPaths = method.getAnnotation(DeleteMapping.class).value();
+        } else if (method.isAnnotationPresent(RequestMapping.class)) {
+            methodPaths = method.getAnnotation(RequestMapping.class).value();
+        }
+
+        if (methodPaths.length == 0) {
+            methodPaths = new String[]{""}; // 메서드 레벨 경로가 없을 경우 빈 문자열로 설정
+        }
+
+        String[] finalMethodPaths = methodPaths;
+        return Arrays.stream(classPaths)
+                .flatMap(classPath -> Arrays.stream(finalMethodPaths).map(methodPath -> classPath + methodPath))
+                .toArray(String[]::new);
+    }
+}


### PR DESCRIPTION
# 컨트롤러 코드에 작성한 순서로 스웨거 api 정렬
## TestController
### 기존 스웨거
<img width="994" alt="스크린샷 2024-07-19 오후 1 41 01" src="https://github.com/user-attachments/assets/c34863f4-494a-4873-8120-2ac819c35506">

### Swaggy-Swagger
<img width="904" alt="스크린샷 2024-07-18 오후 11 47 34" src="https://github.com/user-attachments/assets/6d1632d7-c9f1-4a08-b3b9-b23dc31468f7">

- 사용자가 컨트롤러에 작성한 순서대로 정렬

> FIXME: 같은 경로 다른 http 메소드가 순서가 이어져 있지 않을 경우 순서가 다르게 나옴(한쪽으로 이어서)
> -> 경로명과 http 메소드 모두 이용해 정렬했을 때도 스웨거 PathItem에서 경로당 http 메소드를 묶어서 관리해서 같은 결과  
> 참고 [feature/ordering-httpmethod 브랜치](https://github.com/Swaggy-Swagger/swagger-custom-java/tree/feature/ordering-httpmethod)

- dependency 추가 (build.gradle):
```
dependencies {
        // asm
        implementation 'org.ow2.asm:asm:9.2'
        implementation 'org.ow2.asm:asm-tree:9.2'
}
```

## 다른 프로젝트에 적용
build.gradle
```
repositories {
    mavenCentral()
    mavenLocal()
}

dependencies {
	// openapi
	implementation 'com.test:swagger-custom:0.0.1-SNAPSHOT' // 버젼 확인
	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
	
	// asm
	implementation 'org.ow2.asm:asm:9.2'
	implementation 'org.ow2.asm:asm-tree:9.2'
}
```

SwaggerConfig, OpenApiConfig 등 스웨거 configuration class
```
(나머지 부분 생략)
import org.springframework.context.annotation.Configuration;
import com.test.swaggercustom.config.SwaggerConfig;
import org.springframework.context.annotation.Import;

@Configuration
@Import(SwaggerConfig.class)
public class OpenApiConfig {
```



