### PR TITLE
fix: to relative and dynamic paths

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/swagger-ui/index.html
+++ b/src/main/resources/META-INF/resources/webjars/swagger-ui/index.html
@@ -3,18 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <title>Custom Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/swagger-ui/swagger-ui.css" />
-    <link rel="stylesheet" type="text/css" href="/swagger-ui/custom.css" />
+    <link rel="stylesheet" type="text/css" href="swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="custom.css" />
 </head>
 <body>
 <div id="swagger-ui"></div>
-<script src="/swagger-ui/swagger-ui-bundle.js"></script>
-<script src="/swagger-ui/swagger-ui-standalone-preset.js"></script>
-<script src="/swagger-ui/custom.js"></script>
+<script src="swagger-ui-bundle.js"></script>
+<script src="swagger-ui-standalone-preset.js"></script>
+<script src="custom.js"></script>
 <script>
     window.onload = function() {
+        const currentPath = window.location.pathname;
+        const basePath = currentPath.split('/swagger-ui')[0];  // swagger-ui 경로 이전까지의 경로를 추출
+        const apiDocsPath = `${basePath}/v3/api-docs`;
+
         const ui = SwaggerUIBundle({
-            url: "/v3/api-docs",
+            url: apiDocsPath,
             dom_id: '#swagger-ui',
             presets: [
                 SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
# fix: to relative and dynamic paths
## Before
다른 프로젝트에 적용시
`/swagger-ui/index.html` 일 경우에만 적용이 되었음

## After
다른 경로일 경우에도 적용이 되도록
- 상대경로 적용
- apiDocsPath 동적으로 불러오기