### PR TITLE
feature: log only when there are actual changes

### DIFF
--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -45,19 +45,10 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
             String currentVersion = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(LocalDateTime.now());
 
             List<Map<String, Object>> changedEndpoints = findChangedEndpoints(oldSpec, newSpec);
-            if (!changedEndpoints.isEmpty()) {
-                updateChangeLog(objectMapper, changedEndpoints, currentVersion);
-            }
-
             List<Map<String, Object>> changedParameters = findChangedParameters(oldSpec, newSpec);
-            if (!changedParameters.isEmpty()) {
-                updateChangeLog(objectMapper, changedParameters, currentVersion);
-            }
-
             List<Map<String, Object>> changedSchemas = findChangedSchemas(oldSpec, newSpec);
-            if (!changedSchemas.isEmpty()) {
-                updateChangeLog(objectMapper, changedSchemas, currentVersion);
-            }
+
+            updateChangeLog(objectMapper, changedEndpoints, changedParameters, changedSchemas, currentVersion);
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -88,7 +79,11 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         objectMapper.writeValue(file, data);
     }
 
-    private void updateChangeLog(ObjectMapper objectMapper, List<Map<String, Object>> differences, String currentVersion) throws IOException {
+    private void updateChangeLog(ObjectMapper objectMapper,
+                                 List<Map<String, Object>> changedEndpoints,
+                                 List<Map<String, Object>> changedParameters,
+                                 List<Map<String, Object>> changedSchemas,
+                                 String currentVersion) throws IOException {
         File changeLogFile = new File(changeLogPath);
         List<Map<String, Object>> existingChangeLog = new ArrayList<>();
         if (changeLogFile.exists()) {
@@ -96,12 +91,29 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         }
 
         Map<String, Object> newLogEntry = new HashMap<>();
-        newLogEntry.put("version", currentVersion);
-        newLogEntry.put("changes", differences);
+        boolean flag = false;
 
-        // change log
-        existingChangeLog.add(0, newLogEntry);
-        saveToFile(objectMapper, changeLogPath, existingChangeLog);
+        if (!changedEndpoints.isEmpty()) {
+            newLogEntry.put("changes", changedEndpoints);
+            flag = true;
+        }
+        if (!changedParameters.isEmpty()) {
+            newLogEntry.put("changes", changedParameters);
+            flag = true;
+        }
+        if (!changedSchemas.isEmpty()) {
+            newLogEntry.put("changes", changedSchemas);
+            flag = true;
+        }
+
+        if (flag) {
+            newLogEntry.put("version", currentVersion);
+
+            // change log
+            existingChangeLog.add(0, newLogEntry);
+            saveToFile(objectMapper, changeLogPath, existingChangeLog);
+        }
+
     }
 
     private List<Map<String, Object>> findChangedEndpoints(Map<String, Object> oldSpec, Map<String, Object> newSpec) {

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -94,15 +94,15 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         boolean flag = false;
 
         if (!changedEndpoints.isEmpty()) {
-            newLogEntry.put("changes", changedEndpoints);
+            newLogEntry.put("endpointChanges", changedEndpoints);
             flag = true;
         }
         if (!changedParameters.isEmpty()) {
-            newLogEntry.put("changes", changedParameters);
+            newLogEntry.put("parameterChanges", changedParameters);
             flag = true;
         }
         if (!changedSchemas.isEmpty()) {
-            newLogEntry.put("changes", changedSchemas);
+            newLogEntry.put("schemaChanges", changedSchemas);
             flag = true;
         }
 

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -44,14 +44,20 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
             // current version
             String currentVersion = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(LocalDateTime.now());
 
-            List<Map<String, Object>> differences = findChangedEndpoints(oldSpec, newSpec);
-            updateChangeLog(objectMapper, differences, currentVersion);
+            List<Map<String, Object>> changedEndpoints = findChangedEndpoints(oldSpec, newSpec);
+            if (!changedEndpoints.isEmpty()) {
+                updateChangeLog(objectMapper, changedEndpoints, currentVersion);
+            }
 
             List<Map<String, Object>> changedParameters = findChangedParameters(oldSpec, newSpec);
-            updateChangeLog(objectMapper, changedParameters, currentVersion);
+            if (!changedParameters.isEmpty()) {
+                updateChangeLog(objectMapper, changedParameters, currentVersion);
+            }
 
             List<Map<String, Object>> changedSchemas = findChangedSchemas(oldSpec, newSpec);
-            updateChangeLog(objectMapper, changedSchemas, currentVersion);
+            if (!changedSchemas.isEmpty()) {
+                updateChangeLog(objectMapper, changedSchemas, currentVersion);
+            }
 
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
# feature: add tracking for parameter and response changes

## Json Snapshot

<details>
<summary> before log example when no changes occured</summary>

```json
{
  "changes" : [ ],
  "version" : "2024-08-18 16:52:18"
}, {
  "changes" : [ ],
  "version" : "2024-08-18 16:52:18"
}, {
  "changes" : [ {
    "summary" : "노트 정보",
    "endpoint" : "/api/v1/fragrance/{fragranceId}/noteinfo",
    "method" : "get",
    "changeType" : "added"
  }, {
    "endpoint" : "/api/v1/fragrance/{fragranceId}/note",
    "method" : "get",
    "oldSummary" : "노트 정보",
    "changeType" : "removed"
  } ],
  "version" : "2024-08-18 16:52:18"
}
``` 

</details>

<details>
<summary> after log example - only for actual changes</summary>

```json
{
  "parameterChanges" : [ {
    "oldParameters" : [ {
      "name" : "id",
      "in" : "path",
      "required" : true,
      "schema" : {
        "type" : "integer",
        "format" : "int64",
        "exampleSetFlag" : false,
        "types" : [ "integer" ]
      }
    } ],
    "newParameters" : [ {
      "name" : "id",
      "in" : "path",
      "required" : true,
      "schema" : {
        "type" : "integer",
        "format" : "int64",
        "exampleSetFlag" : false,
        "types" : [ "integer" ]
      }
    }, {
      "name" : "testNum",
      "in" : "query",
      "required" : true,
      "schema" : {
        "type" : "integer",
        "format" : "int32",
        "exampleSetFlag" : false,
        "types" : [ "integer" ]
      }
    } ],
    "endpoint" : "/plan/{id}",
    "method" : "get",
    "changeType" : "parameters_modified"
  } ],
  "schemaChanges" : [ {
    "changeType" : "schema_modified",
    "oldSchema" : {
      "type" : "object",
      "properties" : {
        "name" : {
          "type" : "string",
          "exampleSetFlag" : false,
          "types" : [ "string" ]
        },
        "count" : {
          "type" : "integer",
          "format" : "int32",
          "exampleSetFlag" : false,
          "types" : [ "integer" ]
        }
      },
      "exampleSetFlag" : false
    },
    "newSchema" : {
      "type" : "object",
      "properties" : {
        "name" : {
          "type" : "string",
          "exampleSetFlag" : false,
          "types" : [ "string" ]
        },
        "count1" : {
          "type" : "integer",
          "format" : "int32",
          "exampleSetFlag" : false,
          "types" : [ "integer" ]
        }
      },
      "exampleSetFlag" : false
    },
    "schemaName" : "TestDto"
  }, {
    "changeType" : "schema_modified",
    "oldSchema" : {
      "type" : "object",
      "properties" : {
        "name" : {
          "type" : "string",
          "exampleSetFlag" : false,
          "types" : [ "string" ]
        },
        "actualAge" : {
          "type" : "integer",
          "format" : "int32",
          "exampleSetFlag" : false,
          "types" : [ "integer" ]
        }
      },
      "exampleSetFlag" : false
    },
    "newSchema" : {
      "type" : "object",
      "properties" : {
        "name" : {
          "type" : "string",
          "exampleSetFlag" : false,
          "types" : [ "string" ]
        },
        "age" : {
          "type" : "integer",
          "format" : "int32",
          "exampleSetFlag" : false,
          "types" : [ "integer" ]
        }
      },
      "exampleSetFlag" : false
    },
    "schemaName" : "TestDto2"
  } ],
  "version" : "2024-08-18 18:29:50",
  "endpointChanges" : [ {
    "summary" : "일정 전체 가져오기",
    "endpoint" : "/plan/all/{date}",
    "method" : "get",
    "changeType" : "added"
  }, {
    "endpoint" : "/plan/all",
    "method" : "get",
    "oldSummary" : "일정 전체 가져오기",
    "changeType" : "removed"
  } ]
}
``` 

</details>

## ToDo
* If multiple parameters are changed, it is not possible to identify which API was modified 