### PR TITLE
feature: change flag in swagger response

### DIFF
--- a/src/main/java/io/swaggy/swagger/customlib/test/TestDto.java
+++ b/src/main/java/io/swaggy/swagger/customlib/test/TestDto.java
@@ -1,8 +1,8 @@
 package io.swaggy.swagger.customlib.test;
 
 public class TestDto {
-    private String name = "testname";
-    private int count1 = 100;
+    private String name;
+    private int count;
 
     public TestDto() {
     }
@@ -11,7 +11,7 @@ public class TestDto {
         return name;
     }
 
-    public int getCount1() {
-        return count1;
+    public int getCount() {
+        return count;
     }
 }

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -62,7 +62,6 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         return endpointChanged || parameterChanged || schemaChanged;
     }
 
-
     private void addCustomFieldsToOpenApi(OpenAPI openApi) {
         openApi.getPaths().forEach((path, pathItem) -> {
             pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
@@ -79,9 +78,6 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
             });
         });
     }
-
-
-
 
     private void saveAndTrackChanges(OpenAPI openAPI) {
         try {

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -74,7 +74,7 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
                     extensions = new HashMap<>();
                     operation.setExtensions(extensions);
                 }
-                extensions.put("is_changed", isChanged);
+                extensions.put("isChanged", isChanged);
             });
         });
     }

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -24,11 +24,64 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
     private final String oldFilePath = "./logs/old_openapi.json";
 
     private Map<String, List<MethodPath>> schemaPaths = new HashMap<>();
+    private List<Map<String, Object>> changedSchemas;
+    private ChangesInPaths changesInPaths;
 
     @Override
     public void customise(OpenAPI openApi) {
         saveAndTrackChanges(openApi);
+        addCustomFieldsToOpenApi(openApi);
     }
+
+    private boolean checkIfChanged(String path, String httpMethod, ChangesInPaths changesInPaths) {
+        // check changes in endpoints
+        boolean endpointChanged = changesInPaths.getChangedEndpoints().stream()
+                .anyMatch(endpoint ->
+                        endpoint.get("endpoint").equals(path) &&
+                                endpoint.get("method").toString().equalsIgnoreCase(httpMethod)
+                );
+
+        // check changes in parameters
+        boolean parameterChanged = changesInPaths.getChangedParameters().stream()
+                .anyMatch(param ->
+                        param.get("endpoint").equals(path) &&
+                                param.get("method").toString().equalsIgnoreCase(httpMethod)
+                );
+
+        // check changes in schemas
+        boolean schemaChanged = changedSchemas.stream()
+                .anyMatch(schema -> {
+                    List<Map<String, Object>> pathInfoList = (List<Map<String, Object>>) schema.get("pathInfo");
+                    return pathInfoList.stream()
+                            .anyMatch(pathInfo ->
+                                    pathInfo.get("path").equals(path) &&
+                                            pathInfo.get("method").toString().equalsIgnoreCase(httpMethod)
+                            );
+                });
+
+        return endpointChanged || parameterChanged || schemaChanged;
+    }
+
+
+    private void addCustomFieldsToOpenApi(OpenAPI openApi) {
+        openApi.getPaths().forEach((path, pathItem) -> {
+            pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
+                String method = httpMethod.toString();
+                boolean isChanged = checkIfChanged(path, method, changesInPaths);
+
+                // add custom field to operation
+                Map<String, Object> extensions = operation.getExtensions();
+                if (extensions == null) {
+                    extensions = new HashMap<>();
+                    operation.setExtensions(extensions);
+                }
+                extensions.put("is_changed", isChanged);
+            });
+        });
+    }
+
+
+
 
     private void saveAndTrackChanges(OpenAPI openAPI) {
         try {
@@ -48,8 +101,8 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
             // current version
             String currentVersion = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(LocalDateTime.now());
 
-            ChangesInPaths changesInPaths = findChangesInPaths(oldSpec, newSpec);
-            List<Map<String, Object>> changedSchemas = findChangedSchemas(oldSpec, newSpec);
+            this.changesInPaths = findChangesInPaths(oldSpec, newSpec);
+            this.changedSchemas = findChangedSchemas(oldSpec, newSpec);
 
             updateChangeLog(objectMapper, changesInPaths.getChangedEndpoints(), changesInPaths.getChangedParameters(), changedSchemas, currentVersion);
 


### PR DESCRIPTION
# feature: change flag in swagger response
### Add 'is_changed' field in swagger response
- change in endpoints
- change in parameters
- change in schema
 
 
 Example Response

```json
"/plan": {
      "get": {
        "tags": [
          "Plan API for Test"
        ],
        "summary": "일정 전체 가져오기",
        "operationId": "getAllPlans",
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "isChanged": true
      },
      "post": {
        "tags": [
          "Plan API for Test"
        ],
        "summary": "일정 추가하기",
        "operationId": "createPlan",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/TestDto"
              }
            }
          },
          "required": true
        },
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "isChanged": false
      }
    },
```