### PR TITLE
Fix: change type in change flag

### DIFF
--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -33,7 +33,7 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         addCustomFieldsToOpenApi(openApi);
     }
 
-    private boolean checkIfChanged(String path, String httpMethod) {
+    private boolean[] checkIfChanged(String path, String httpMethod) {
         // check changes in endpoints
         boolean endpointChanged = changesInPaths.getChangedEndpoints().stream()
                 .anyMatch(endpoint ->
@@ -59,14 +59,14 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
                             );
                 });
 
-        return endpointChanged || parameterChanged || schemaChanged;
+        return new boolean[]{endpointChanged, parameterChanged, schemaChanged};
     }
 
     private void addCustomFieldsToOpenApi(OpenAPI openApi) {
         openApi.getPaths().forEach((path, pathItem) -> {
             pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
                 String method = httpMethod.toString();
-                boolean isChanged = checkIfChanged(path, method);
+                boolean[] isChanged = checkIfChanged(path, method);
 
                 // add custom field to operation
                 Map<String, Object> extensions = operation.getExtensions();
@@ -74,7 +74,9 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
                     extensions = new HashMap<>();
                     operation.setExtensions(extensions);
                 }
-                extensions.put("isChanged", isChanged);
+                extensions.put("endpointChanged", isChanged[0]);
+                extensions.put("parameterChanged", isChanged[1]);
+                extensions.put("schemaChanged", isChanged[2]);
             });
         });
     }

--- a/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
+++ b/src/main/java/io/swaggy/swagger/customlib/utils/OpenApiChangeTracker.java
@@ -33,7 +33,9 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
         addCustomFieldsToOpenApi(openApi);
     }
 
-    private boolean[] checkIfChanged(String path, String httpMethod) {
+    private List<String> checkIfChanged(String path, String httpMethod) {
+        List<String> changedTypes = new ArrayList<>();
+
         // check changes in endpoints
         boolean endpointChanged = changesInPaths.getChangedEndpoints().stream()
                 .anyMatch(endpoint ->
@@ -59,14 +61,20 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
                             );
                 });
 
-        return new boolean[]{endpointChanged, parameterChanged, schemaChanged};
+        // Add types to list if changed
+        if (endpointChanged) changedTypes.add("Endpoint");
+        if (parameterChanged) changedTypes.add("Parameter");
+        if (schemaChanged) changedTypes.add("Schema");
+
+        return changedTypes;
     }
+
 
     private void addCustomFieldsToOpenApi(OpenAPI openApi) {
         openApi.getPaths().forEach((path, pathItem) -> {
             pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
                 String method = httpMethod.toString();
-                boolean[] isChanged = checkIfChanged(path, method);
+                List<String> isChanged = checkIfChanged(path, method);
 
                 // add custom field to operation
                 Map<String, Object> extensions = operation.getExtensions();
@@ -74,9 +82,8 @@ public class OpenApiChangeTracker implements OpenApiCustomizer {
                     extensions = new HashMap<>();
                     operation.setExtensions(extensions);
                 }
-                extensions.put("endpointChanged", isChanged[0]);
-                extensions.put("parameterChanged", isChanged[1]);
-                extensions.put("schemaChanged", isChanged[2]);
+                extensions.put("isChanged", !isChanged.isEmpty());
+                extensions.put("changedTypes", isChanged);
             });
         });
     }


### PR DESCRIPTION
# Fix: change type in change flag

- Add change type (Endpoint, Parameter, Schema)
```json
"/plan": {
      "get": {
        "tags": [
          "Plan API for Test"
        ],
        "summary": "일정 전체 가져오기",
        "operationId": "getAllPlans",
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "isChanged": true,
        "changedTypes": [
          "Endpoint",
          "Parameter"
        ]
      },
      "post": {
        "tags": [
          "Plan API for Test"
        ],
        "summary": "일정 추가하기",
        "operationId": "createPlan",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/TestDto"
              }
            }
          },
          "required": true
        },
        "responses": {
          "200": {
            "description": "OK"
          }
        },
        "isChanged": false,
        "changedTypes": []
      }
    },
```
-  For more context: [feature: change flag in swagger response #9](https://github.com/Swaggy-Swagger/swagger-custom-java/pull/9)